### PR TITLE
Remove quotation from around %mod% in bat files and add g_password entry in dedicated_sp.cfg

### DIFF
--- a/!start_mp_server.bat
+++ b/!start_mp_server.bat
@@ -22,6 +22,6 @@ echo (%date%)  -  (%time%) %name% server start.
 
 cd /D %LOCALAPPDATA%\Plutonium
 :server
-start /wait /abovenormal bin\plutonium-bootstrapper-win32.exe t5mp "%gamepath%" -dedicated +set key %key% +set fs_game "%mod%" +exec "%cfg%" +set net_port %port% +set sv_maxclients %maxclients% +map_rotate
+start /wait /abovenormal bin\plutonium-bootstrapper-win32.exe t5mp "%gamepath%" -dedicated +set key %key% +set fs_game %mod% +exec "%cfg%" +set net_port %port% +set sv_maxclients %maxclients% +map_rotate
 echo (%date%)  -  (%time%) WARNING: %name% server closed or dropped... server restarts.
 goto server

--- a/!start_zm_server.bat
+++ b/!start_zm_server.bat
@@ -22,6 +22,6 @@ echo (%date%)  -  (%time%) %name% server start.
 
 cd /D %LOCALAPPDATA%\Plutonium
 :server
-start /wait /abovenormal bin\plutonium-bootstrapper-win32.exe t5sp "%gamepath%" -dedicated +set key %key% +set fs_game "%mod%" +exec "%cfg%" +set net_port %port% +set sv_maxclients %maxclients% +map_rotate
+start /wait /abovenormal bin\plutonium-bootstrapper-win32.exe t5sp "%gamepath%" -dedicated +set key %key% +set fs_game %mod% +exec "%cfg%" +set net_port %port% +set sv_maxclients %maxclients% +map_rotate
 echo (%date%)  -  (%time%) WARNING: %name% server closed or dropped... server restarts.
 goto server

--- a/localappdata/Plutonium/storage/t5/dedicated_sp.cfg
+++ b/localappdata/Plutonium/storage/t5/dedicated_sp.cfg
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////
 
 set g_inactivity "190"                              // Enable or Disable auto kick feature for idle/AFK players.
+set g_password ""                                   // Require a password to join your server. (Use "password <yourpassword>" to set it on the client before connecting)
 set sv_disableClientConsole "0"                     // Enable or Disable players ability to access server commands
 set sv_floodProtect "1"                             // Chat Spam Protection.(Set this to 20 if you are using a RCon tool)
 set sv_kickBanTime "300"                            // Kick Ban Duration. Time before player can re-join the server after getting kicked.


### PR DESCRIPTION
Removed quotation from around %mod% to prevent boot loop when no mod is loaded

![image](https://github.com/user-attachments/assets/89fbe87f-6d87-47e9-bc39-993f816cde8f)

Also, added g_password in `dedicated_sp.cfg`